### PR TITLE
Build more icons, better build logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ dist
 dist-icons
 dist-site
 public/**/*
+pngs/
+.env.aoai
 
 # negate
 !public/.gitkeep

--- a/README.md
+++ b/README.md
@@ -15,9 +15,6 @@
 > Five out of vibe stars  
 > —Vibecon Awards
 
-
-
-
 ## Keyboard Shortcuts
 
 | Key                                                 | Action                   | When              |
@@ -32,3 +29,15 @@
 | Double click a tile                                 | Copy SVG                 |                   |
 
 \*Search with AI requires a valid Azure OpenAI connection. Click the AI Foundry button in the corner of the screen to set it up.
+
+## Development
+
+1. `npm install`
+2. `npm run setup`
+
+- clones the [Fluent Icons](https://github.com/microsoft/fluentui-system-icons/) repo assets folder
+- builds the public folder icons.svg
+
+3. `npm run dev`
+
+http://localhost:5173/vibe-icon/dev.html for development of vibe-icon web component

--- a/scripts/build-log.ts
+++ b/scripts/build-log.ts
@@ -1,0 +1,58 @@
+// Build logging system
+interface BuildLogEntry {
+  timestamp: string;
+  stage: string;
+  level: 'info' | 'warn' | 'error';
+  message: string;
+  details?: any;
+}
+
+interface BuildLog {
+  startTime: string;
+  endTime?: string;
+  commit?: string;
+  summary: {
+    totalIcons: number;
+    processedIcons: number;
+    totalErrors: number;
+    stageErrors: {
+      processing: number;
+      compiling: number;
+      metadata: number;
+    };
+  };
+  sizeStats?: any;
+  entries: BuildLogEntry[];
+}
+
+export const buildLog: BuildLog = {
+  startTime: new Date().toISOString(),
+  summary: {
+    totalIcons: 0,
+    processedIcons: 0,
+    totalErrors: 0,
+    stageErrors: {
+      processing: 0,
+      compiling: 0,
+      metadata: 0
+    }
+  },
+  entries: []
+};
+
+export function logEntry(stage: string, level: 'info' | 'warn' | 'error', message: string, details?: any) {
+  buildLog.entries.push({
+    timestamp: new Date().toISOString(),
+    stage,
+    level,
+    message,
+    details
+  });
+  
+  if (level === 'error' || level === 'warn') {
+    buildLog.summary.totalErrors++;
+    if (stage === 'processing') buildLog.summary.stageErrors.processing++;
+    else if (stage === 'compiling') buildLog.summary.stageErrors.compiling++;
+    else if (stage === 'metadata') buildLog.summary.stageErrors.metadata++;
+  }
+}

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -43,8 +43,8 @@ async function fetchRepoAssets(): Promise<string> {
   console.log("Fetching repository assets...");
   await execAsync(`git clone --filter=blob:none --sparse https://github.com/microsoft/fluentui-system-icons.git ${outDir}`);
   console.log("Filtering repository assets...");
-  await execAsync(`cd ${outDir} && git sparse-checkout set --no-cone`);
-  await execAsync(`cd ${outDir} && git sparse-checkout set 'assets/**/*.svg' 'assets/**/*.json'`);
+  await execAsync(`cd ${outDir} && git sparse-checkout init --cone`);
+  await execAsync(`cd ${outDir} && git sparse-checkout set assets`);
 
   // Get the commit ID
   const { stdout } = await execAsync(`cd ${outDir} && git rev-parse HEAD`);

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -35,16 +35,51 @@ async function fetchRepoAssets(): Promise<string> {
   // Create temp directory if it doesn't exist
   try {
     await rm(outDir, { recursive: true });
-  } catch {}
+    console.log("✓ Removed existing dist-icons directory");
+  } catch {
+    console.log("✓ No existing dist-icons directory to remove");
+  }
 
   await mkdirSync(outDir, { recursive: true });
+  console.log("✓ Created dist-icons directory");
 
   // Clone the repository with sparse checkout to get only the assets folder
   console.log("Fetching repository assets...");
   await execAsync(`git clone --filter=blob:none --sparse https://github.com/microsoft/fluentui-system-icons.git ${outDir}`);
+  console.log("✓ Git clone completed");
+
+  // Check what's in the directory after clone
+  try {
+    const clonedContents = await readdir(outDir);
+    console.log(`✓ Contents after clone: ${clonedContents.join(', ')}`);
+  } catch (error) {
+    console.log(`✗ Error reading cloned directory: ${error}`);
+  }
+
   console.log("Filtering repository assets...");
   await execAsync(`cd ${outDir} && git sparse-checkout init --cone`);
+  console.log("✓ Sparse checkout initialized");
+  
   await execAsync(`cd ${outDir} && git sparse-checkout set assets`);
+  console.log("✓ Sparse checkout patterns set");
+
+  // Check what's in the directory after sparse checkout
+  try {
+    const contentsAfterSparse = await readdir(outDir);
+    console.log(`✓ Contents after sparse checkout: ${contentsAfterSparse.join(', ')}`);
+    
+    // Check if assets directory exists
+    const assetsPath = resolve(outDir, "assets");
+    try {
+      const assetsContents = await readdir(assetsPath);
+      console.log(`✓ Assets directory found with ${assetsContents.length} items`);
+      console.log(`✓ First few assets: ${assetsContents.slice(0, 5).join(', ')}`);
+    } catch (assetsError) {
+      console.log(`✗ Assets directory not found: ${assetsError}`);
+    }
+  } catch (error) {
+    console.log(`✗ Error reading directory after sparse checkout: ${error}`);
+  }
 
   // Get the commit ID
   const { stdout } = await execAsync(`cd ${outDir} && git rev-parse HEAD`);
@@ -54,6 +89,7 @@ async function fetchRepoAssets(): Promise<string> {
 
   // remove the .git directory to clean up
   await rm(resolve(outDir, ".git"), { recursive: true });
+  console.log("✓ Cleaned up .git directory");
 
   return commitId;
 }
@@ -62,6 +98,17 @@ async function buildIconIndex(
   commitId: string
 ): Promise<{ index: IconIndex; metadata: Record<string, { options: IconOption[] }>; iconDirMap: Map<string, string> }> {
   const assetsDir = resolve(outDir, "assets");
+  console.log(`📁 Attempting to read assets directory: ${assetsDir}`);
+  
+  // Debug: Check if the directory exists and what's in the parent directory
+  try {
+    const parentDir = resolve(outDir);
+    const parentContents = await readdir(parentDir);
+    console.log(`📁 Parent directory (${parentDir}) contents: ${parentContents.join(', ')}`);
+  } catch (error) {
+    console.log(`✗ Error reading parent directory: ${error}`);
+  }
+  
   const assetFolders = await readdir(assetsDir);
   const filenamePattern = /(.+)_(\d+)_(filled|regular)\.svg/;
   const metadataMap = new Map<string, { name: string; options: IconOption[] }>();
@@ -88,7 +135,7 @@ async function buildIconIndex(
         iconDirMap.set(displayName, folderPath);
       } catch {
         // metadata.json doesn't exist or is invalid - skip this folder
-        console.log(`Skipping folder ${folder}: no metadata.json found`);
+        // console.log(`Skipping folder ${folder}: no metadata.json found`);
         return null;
       }
 
@@ -142,7 +189,7 @@ async function buildIconIndex(
           return 0;
         });
 
-        console.log(`Processed icon ${++progress}/${assetFolders.length}: ${displayName}`);
+        // console.log(`Processed icon ${++progress}/${assetFolders.length}: ${displayName}`);
       } catch (error) {
         throw new Error(`Failed to read SVG files for icon ${displayName}: ${error}`);
       }
@@ -273,7 +320,7 @@ async function compileIconSvgs(iconIndex: IconIndex, metadata: MetadataMap, icon
         }
       }
 
-      console.log(`Compiled icon ${++progress}/${totalIcons}: ${displayName} (size: ${targetSize})`);
+      // console.log(`Compiled icon ${++progress}/${totalIcons}: ${displayName} (size: ${targetSize})`);
       sizeFrequency[targetSize] ??= 0;
       sizeFrequency[targetSize]++;
     }, 8)
@@ -316,7 +363,7 @@ async function saveMetadata(metadata: MetadataMap) {
       const fileName = displayNameToVibeIconSVGFilename(name);
       const filePath = resolve(publicDir, `${fileName}.metadata.json`);
       await writeFile(filePath, JSON.stringify({ name, options }, null, 2), "utf-8");
-      console.log(`Metadata saved ${++progress}/${totalMetadata}: ${name}`);
+      // console.log(`Metadata saved ${++progress}/${totalMetadata}: ${name}`);
     }, 8)
   );
 

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -110,13 +110,13 @@ async function fetchRepoAssets(): Promise<string> {
 
 async function buildIconIndex(commitId: string): Promise<{
   iconIndex: IconIndex;
-  metadata: Record<string, { options: IconOption[] }>;
+  metadata: MetadataMap;
   iconDirMap: Map<string, string>;
 }> {
   const assetsDir = resolve(outDir, "assets");
   const assetFolders = await readdir(assetsDir);
   const filenamePattern = /(.+)_(\d+)_(filled|regular)\.svg/;
-  const metadataMap = new Map<string, { name: string; options: IconOption[] }>();
+  const metadataMap = new Map<string, { name: string; metaphor: string[]; options: IconOption[] }>();
   // Given an icon's display name, what is the full path of the dir that contains the metadata.json?
   const iconDirMap = new Map<string, string>();
 
@@ -210,7 +210,7 @@ async function buildIconIndex(commitId: string): Promise<{
           return 0;
         });
 
-      metadataMap.set(displayName, { name: displayName, options: actualOptions });
+      metadataMap.set(displayName, { name: displayName, metaphor: metaphor, options: actualOptions });
 
       const allSizes = [...new Set(actualOptions.map((opt) => opt.size))];
       updateProgress(++progress, assetFolders.length, "Processing icons", errors);
@@ -234,7 +234,7 @@ async function buildIconIndex(commitId: string): Promise<{
           })
       ),
     },
-    metadata: Object.fromEntries(Array.from(metadataMap.entries()).map(([name, { options }]) => [name, { options }])),
+    metadata: Object.fromEntries(Array.from(metadataMap.entries()).map(([name, { metaphor, options }]) => [name, { metaphor, options }])),
     iconDirMap,
   };
 }
@@ -411,11 +411,11 @@ async function saveMetadata(metadata: MetadataMap) {
   let errors = 0;
 
   const metadata$ = from(Object.entries(metadata)).pipe(
-    mergeMap(async ([name, { options }]) => {
+    mergeMap(async ([name, { metaphor, options }]) => {
       const fileName = displayNameToVibeIconSVGFilename(name);
       const filePath = resolve(publicDir, `${fileName}.metadata.json`);
       try {
-        await writeFile(filePath, JSON.stringify({ name, options }, null, 2), "utf-8");
+        await writeFile(filePath, JSON.stringify({ name, metaphor, options }, null, 2), "utf-8");
       } catch (error) {
         logEntry('metadata', 'warn', `Failed to save metadata for ${name}`, { error: String(error) });
         errors++;

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -198,7 +198,10 @@ async function compileIconSvgs(iconIndex: IconIndex, metadata: MetadataMap, icon
   mkdirSync(publicDir, { recursive: true });
 
   let progress = 0;
-  let sizeFrequency: Record<number, number> = {};
+  let sizeFrequency: { allSizes: Record<number, number>; targetSize: Record<number, number> } = {
+    allSizes: {},
+    targetSize: {},
+  };
   const totalIcons = Object.keys(iconIndex.icons).length;
   const icons$ = from(Object.entries(iconIndex.icons)).pipe(
     mergeMap(async ([displayName, [_metaphor, options]]) => {
@@ -267,15 +270,17 @@ async function compileIconSvgs(iconIndex: IconIndex, metadata: MetadataMap, icon
             content = content.replaceAll(/fill="#\d+"/g, 'fill="currentColor"');
 
             await writeFile(outputFilePath, content, "utf-8");
+            sizeFrequency.allSizes[size] ??= 0;
+            sizeFrequency.allSizes[size]++;
           } catch (error) {
             console.error(`Failed to process ${svgFileName}: ${error}`);
           }
         }
       }
 
-      console.log(`Compiled icon ${++progress}/${totalIcons}: ${displayName} (size: ${targetSize})`);
-      sizeFrequency[targetSize] ??= 0;
-      sizeFrequency[targetSize]++;
+      // console.log(`Compiled icon ${++progress}/${totalIcons}: ${displayName} (size: ${targetSize})`);
+      sizeFrequency.targetSize[targetSize] ??= 0;
+      sizeFrequency.targetSize[targetSize]++;
     }, 8)
   );
 
@@ -316,7 +321,7 @@ async function saveMetadata(metadata: MetadataMap) {
       const fileName = displayNameToVibeIconSVGFilename(name);
       const filePath = resolve(publicDir, `${fileName}.metadata.json`);
       await writeFile(filePath, JSON.stringify({ name, options }, null, 2), "utf-8");
-      console.log(`Metadata saved ${++progress}/${totalMetadata}: ${name}`);
+      // console.log(`Metadata saved ${++progress}/${totalMetadata}: ${name}`);
     }, 8)
   );
 

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -125,12 +125,14 @@ async function buildIconIndex(commitId: string): Promise<{
 
   const icons$ = from(assetFolders).pipe(
     mergeMap(async (folder) => {
-      const folderPath = resolve(assetsDir, folder);
 
-      // DEV: Only process icons starting with "a" for faster testing
-      // if (!folder.toLowerCase().startsWith("a")) {
-      //   return null;
-      // }
+      // throw out the rtl, ltr, and temp icons - the are duplicates and don't parse the same as the regular icons
+      if (folder.includes(" RTL") || folder.includes(" LTR") || folder.includes(" Temp ")) {
+        logEntry('processing', 'warn', `Skipping folder ${folder}: contains RTL, LTR, or Temp`);
+        return null;
+      }
+
+      const folderPath = resolve(assetsDir, folder);
 
       // First, scan SVG files to get actual available options
       let actualOptions: IconOption[] = [];

--- a/scripts/progress-bar.ts
+++ b/scripts/progress-bar.ts
@@ -20,17 +20,17 @@ export function progressSpinner(stage: string) {
   const spinnerFrames = ['|', '/', '-', '\\'];
   
   spinnerIndex = 0;
-  process.stdout.write(`${stage}: ${spinnerFrames[spinnerIndex]}`);
+  process.stdout.write(`${spinnerFrames[spinnerIndex]} > ${stage}`);
   spinnerInterval = setInterval(() => {
     spinnerIndex = (spinnerIndex + 1) % spinnerFrames.length;
-    process.stdout.write(`\r${stage}: ${spinnerFrames[spinnerIndex]}`);
+    process.stdout.write(`\r${spinnerFrames[spinnerIndex]} > ${stage}`);
   }, 100);
   
   return function stopSpinner() {
     if (spinnerInterval) {
       clearInterval(spinnerInterval);
       spinnerInterval = null;
-      process.stdout.write(`\r${stage ? stage + ': ' : ''}Done\n`);
+      process.stdout.write(`\rDone > ${stage}\n`);
     }
   }
 }

--- a/scripts/progress-bar.ts
+++ b/scripts/progress-bar.ts
@@ -1,0 +1,37 @@
+// Simple progress bar function
+export function updateProgress(current: number, total: number, stage: string, errors: number = 0) {
+  const percentage = Math.round((current / total) * 100);
+  const barLength = 30;
+  const filledLength = Math.round((barLength * current) / total);
+  const bar = '█'.repeat(filledLength) + '░'.repeat(barLength - filledLength);
+  
+  const errorText = errors > 0 ? ` | ${errors} errors` : '';
+  process.stdout.write(`\r${stage}: [${bar}] ${percentage}% (${current}/${total})${errorText}`);
+  if (current === total) {
+    process.stdout.write('\n');
+  }
+}
+
+// Simple spinner for indefinite progress
+
+export function progressSpinner(stage: string) {
+  let spinnerInterval: NodeJS.Timeout | null = null;
+  let spinnerIndex = 0;
+  const spinnerFrames = ['|', '/', '-', '\\'];
+  
+  spinnerIndex = 0;
+  process.stdout.write(`${stage}: ${spinnerFrames[spinnerIndex]}`);
+  spinnerInterval = setInterval(() => {
+    spinnerIndex = (spinnerIndex + 1) % spinnerFrames.length;
+    process.stdout.write(`\r${stage}: ${spinnerFrames[spinnerIndex]}`);
+  }, 100);
+  
+  return function stopSpinner() {
+    if (spinnerInterval) {
+      clearInterval(spinnerInterval);
+      spinnerInterval = null;
+      process.stdout.write(`\r${stage ? stage + ': ' : ''}Done\n`);
+    }
+  }
+}
+

--- a/typings/icon-index.d.ts
+++ b/typings/icon-index.d.ts
@@ -3,10 +3,11 @@ export interface IconIndex {
   icons: Record<string, [metaphors: string[], options: IconOption[], sizes: number[]]>;
 }
 
-export type MetadataMap = Record<string, { options: IconOption[] }>;
+export type MetadataMap = Record<string, { metaphor: string[]; options: IconOption[] }>;
 
 export interface MetadataEntry {
   name: string;
+  metaphor: string[];
   options: IconOption[];
 }
 


### PR DESCRIPTION
WARNING - this PR contains PR #4 

As I was setting up my branch for the emoji matching, I modified the build script to catch more icons and log more of what is happening. There also now a build-log.json file saved to public, and we are skipping "RTL" and "LTR" icons.

The main change - we are now looking at the existing .svg files to determine the sizes and styles, instead of looking at the metadata.json. The metadata.json was unreliable data, and some icons didn't have it. Now it is created if it does not exist (but it does not contain any metaphors)

- Previously there were 2606 icons
- Now there are 2737

For example, these "Agent" icons were not included in the last build:
![image](https://github.com/user-attachments/assets/dbb84c24-c305-4c5c-9296-647bda830c11)


